### PR TITLE
Update README.md: Recommend cloning over HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This package is a collection of Julia packages used by the Brown Center for Biom
 
 ## Installation
 ```julia
-Pkg.clone("http://github.com/bcbi/BCBI_base.jl.git")
+Pkg.clone("https://github.com/bcbi/BCBI_base.jl.git")
 ```
 
 ## Other Dependencies


### PR DESCRIPTION
Recommend cloning over HTTPS instead of HTTP for increased security.